### PR TITLE
allow tab to accept search result

### DIFF
--- a/src/components/searchItemField.tsx
+++ b/src/components/searchItemField.tsx
@@ -14,6 +14,9 @@ export const SearchItemField = (props: SearchItemFieldProps) => {
   const { items: wfItems } = useCacheContext();
   const [items, setItems] = useState<Array<Wfm.ItemDto & { label: string, value: string }>>([]);
   const { value, onChange } = props;
+  const [filteredItems, setFilteredItems] = useState(items);
+  const [lastKeyPressed, setLastKeyPressed] = useState<string | null>(null);
+
   useEffect(() => {
     setItems(wfItems.map((warframe) => ({ ...warframe, label: warframe.item_name, value: warframe.url_name })) || []);
   }, [wfItems]);
@@ -30,6 +33,21 @@ export const SearchItemField = (props: SearchItemFieldProps) => {
       maxDropdownHeight={400}
       nothingFound={useTranslateSearch('no_results')}
       value={value}
+      onKeyDown={(event) => {
+        setLastKeyPressed(event.key);
+      }}
+      onSearchChange={(searchValue) => {
+        setFilteredItems(
+          items.filter(item => item.label.toLowerCase().includes(searchValue.toLowerCase()))
+        );
+      }}
+      onBlur={() => {
+        if (lastKeyPressed === 'Tab' && filteredItems.length > 0) {
+          const firstItem = filteredItems[0];
+          onChange(firstItem);
+        }
+        setLastKeyPressed(null);
+      }}
       onChange={async (value) => {
         if (!value) return;
         const item = items.find(item => item.url_name === value);


### PR DESCRIPTION
https://discord.com/channels/1129235967769845871/1175002398914256946
Basic impl for a suggestion I made regarding handling tab key input on SearchItemField.
Pressing tab will now use the first search result as the value for the SearchItemField in transaction view and move to the next textbox as usual.
