### PR TITLE
Change daily profit transaction calculation from Local to UTC time

### DIFF
--- a/src/api/statistic/index.ts
+++ b/src/api/statistic/index.ts
@@ -154,8 +154,8 @@ export class StatisticModule {
   }
 
   private GetToDayProfit(transactions: TransactionDto[]): StatisticProfitTransactionToday {
-    let today = dayjs().startOf("day").toDate();
-    let endToday = dayjs().endOf('day').toDate();
+    let today = dayjs().utc().startOf("day").toDate();
+    let endToday = dayjs().utc().endOf('day').toDate();
     const labels = [];
     for (let i = 0; i < 24; i++) labels.push(`${i}:00`);
 


### PR DESCRIPTION
Suggestion: Since daily trades available are reset at midnight UTC, the daily profit would seem to make more sense if calculated based on the same day's trades. This way users can see more accurately how they performed using trades on the same reset, even if that is across days in local time so there can be an even comparison reset to reset.