### PR TITLE
fix: app.order.error.exceededOrderLimitSamePrice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ dist-ssr
 
 # Editor directories and files
 .vscode/*
+.vs
 !.vscode/extensions.json
 .idea
 .DS_Store


### PR DESCRIPTION
check my thrash fix, at least now you know where to dig

Also i've noticed "EOF while parsing a value" error: 

`[2025-12-12 01:44:39] [755.5696] [CRITICAL] [LiveScraper:WarframeMarket] Location: src\wfm_client\client.rs:217:21, Could not parse response: , Error("EOF while parsing a value", line: 1, column: 0) The request failed with status code 500 to the url: https://api.warframe.market/v2/order/693b62d165d3e2454b047818 with the following message: EOF while parsing a value at line 1 column 0, Extra: <{"ApiError":{"body":{"platinum":44,"quantity":1,"visible":true},"error":"RequestError","messages":["EOF while parsing a value at line 1 column 0"],"method":"PATCH","raw_response":"","statusCode":500,"url":"https://api.warframe.market/v2/order/693b62d165d3e2454b047818"}}>`