### PR TITLE
Add fake order simulation, fix Max Total Price Cap logic and add Knapsack skip logging

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -1867,6 +1867,8 @@
         },
         "debugging": {
           "title": "Debugging",
+          "fake_orders_tooltip": "Toggle Fake Orders for Live Trading (For Testing Purposes Only) will be stored in dev.kenya.quantframe\\fake_orders",
+          "fake_orders_label": "Use Fake Orders Live orders",
           "datatable": {
             "columns": {
               "wfm_url": {

--- a/src-tauri/src/app/types/debugging_settings.rs
+++ b/src-tauri/src/app/types/debugging_settings.rs
@@ -18,12 +18,14 @@ impl Default for DebuggingSettings {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct DebuggingLiveScraperSettings {
     pub entries: Vec<ItemEntry>,
+    pub fake_orders: bool,
 }
 
 impl Default for DebuggingLiveScraperSettings {
     fn default() -> Self {
         DebuggingLiveScraperSettings {
             entries: Vec::new(),
+            fake_orders: false,
         }
     }
 }

--- a/src-tauri/src/handlers/base.rs
+++ b/src-tauri/src/handlers/base.rs
@@ -18,6 +18,7 @@ pub async fn handle_wfm_item(
 ) -> Result<String, Error> {
     let wfm_id = wfm_id.into();
     let app = states::app_state()?;
+    let settings = &app.settings.live_scraper;
     let component = "HandleWFMItem";
     let file = "handle_wfm_item.log";
     let mut operation_status = "NoOrder".to_string();

--- a/src-tauri/utils/src/helper.rs
+++ b/src-tauri/utils/src/helper.rs
@@ -116,6 +116,27 @@ pub fn read_json_file<T: serde::de::DeserializeOwned>(path: &PathBuf) -> Result<
         )),
     }
 }
+
+/**
+ * Writes a serializable object to a JSON file at the specified path.
+ * Creates parent directories if they do not exist.
+ * # Arguments
+ * * `path` - The file path to write the JSON data to
+ * * `data` - The serializable object to write
+ */
+pub fn write_json_file<T: serde::Serialize>(
+    path: impl AsRef<std::path::Path>,
+    data: &T,
+) -> std::io::Result<()> {
+    let path_ref = path.as_ref();
+    // Check if the folder exists
+    if let Some(parent) = path_ref.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let file = std::fs::File::create(path_ref)?;
+    serde_json::to_writer(file, data)?;
+    Ok(())
+}
 /// Find an object in a Vec<T> by multiple criteria using a predicate function
 ///
 /// # Arguments

--- a/src/components/DataDisplay/ChatMessage/ChatMessage.tsx
+++ b/src/components/DataDisplay/ChatMessage/ChatMessage.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from "react";
 import dayjs from "dayjs";
 import calendar from "dayjs/plugin/calendar";
 dayjs.extend(calendar);
+import { decodeHtmlEntities } from "@utils/helper";
 
 export type ChatMessageProps = {
   user: WFMarketTypes.User | undefined;
@@ -42,7 +43,7 @@ export const ChatMessage = ({ user, msg, sender }: ChatMessageProps) => {
                   setOpen((o) => !o);
                 }}
               >
-                {msg.raw_message}
+                {decodeHtmlEntities(msg.raw_message)}
               </Alert>
             </Group>
           </Stack>

--- a/src/pages/debug/tabs/debugging/index.tsx
+++ b/src/pages/debug/tabs/debugging/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Group } from "@mantine/core";
+import { Box, Checkbox, Group, Tooltip } from "@mantine/core";
 import { DataTable } from "mantine-datatable";
 import { useTranslatePages } from "@hooks/useTranslate.hook";
 import { useHasAlert } from "@hooks/useHasAlert.hook";
@@ -23,17 +23,34 @@ export const DebuggingPanel = ({}: DebuggingPanelProps) => {
 
   return (
     <Box>
-      <DebuggingLiveItemEntryForm
-        onSubmit={async (values) => {
-          if (!settings) return;
-          let items = [...(settings?.debugging.live_scraper.entries || []), values];
-          await api.app.updateSettings({
-            ...settings,
-            debugging: { ...settings.debugging, live_scraper: { ...settings.debugging.live_scraper, entries: items } },
-          });
-          SendTauriEvent(TauriTypes.Events.RefreshSettings);
-        }}
-      />
+      <Group align="center">
+        <DebuggingLiveItemEntryForm
+          onSubmit={async (values) => {
+            if (!settings) return;
+            let items = [...(settings?.debugging.live_scraper.entries || []), values];
+            await api.app.updateSettings({
+              ...settings,
+              debugging: { ...settings.debugging, live_scraper: { ...settings.debugging.live_scraper, entries: items } },
+            });
+            SendTauriEvent(TauriTypes.Events.RefreshSettings);
+          }}
+        />
+        <Tooltip label={useTranslateTabDebugging("fake_orders_tooltip")}>
+          <Checkbox
+            label={useTranslateTabDebugging("fake_orders_label")}
+            checked={settings?.debugging.live_scraper.fake_orders || false}
+            size="sm"
+            onChange={async (e) => {
+              if (!settings) return;
+              await api.app.updateSettings({
+                ...settings,
+                debugging: { ...settings.debugging, live_scraper: { ...settings.debugging.live_scraper, fake_orders: e.currentTarget.checked } },
+              });
+              SendTauriEvent(TauriTypes.Events.RefreshSettings);
+            }}
+          />
+        </Tooltip>
+      </Group>
       <DataTable
         height={400}
         className={`${classes.dataTableLogging}`}

--- a/src/types/tauri.type.ts
+++ b/src/types/tauri.type.ts
@@ -102,6 +102,7 @@ export namespace TauriTypes {
   export interface SettingsDebugging {
     live_scraper: {
       entries: DebuggingLiveItemEntry[];
+      fake_orders: boolean;
     };
   }
   export interface ManualUpdate {
@@ -490,8 +491,8 @@ export namespace TauriTypes {
   export interface ChartWithLabelsDto {
     labels: Array<string>;
   }
-  export interface ChartDto extends ChartWithValuesDto, ChartWithLabelsDto { }
-  export interface ChartMultipleDto extends ChartWithMultipleValuesDto, ChartWithLabelsDto { }
+  export interface ChartDto extends ChartWithValuesDto, ChartWithLabelsDto {}
+  export interface ChartMultipleDto extends ChartWithMultipleValuesDto, ChartWithLabelsDto {}
   export interface TradingSummaryDto {
     best_selling_items: TransactionItemSummaryDto[];
     category_summary: TransactionCategorySummaryDto[];
@@ -723,7 +724,7 @@ export namespace TauriTypes {
     name: string;
   }
 
-  export interface StockRivenDetails extends RivenSummary { }
+  export interface StockRivenDetails extends RivenSummary {}
   export interface SubType {
     rank?: number;
     variant?: string;
@@ -828,7 +829,7 @@ export namespace TauriTypes {
     created_at: string;
     properties: Record<string, any>;
   }
-  export interface TradeEntryDetails extends TradeEntry { }
+  export interface TradeEntryDetails extends TradeEntry {}
 
   export interface CreateTradeEntry {
     raw: string;

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -285,6 +285,16 @@ export const GetItemDisplay = (
   if ("mod_name" in value) fullName += ` ${value.mod_name}`;
   return fullName || "Unknown Item";
 };
+
+export const decodeHtmlEntities = (input: string): string => {
+  try {
+    const doc = new DOMParser().parseFromString(input, "text/html");
+    return doc.documentElement.textContent || "";
+  } catch {
+    return input;
+  }
+};
+
 // At the top of your component or in a separate utils file
 export const getSafePage = (requestedPage: number | undefined, totalPages: number | undefined): number => {
   const page = requestedPage ?? 1;


### PR DESCRIPTION
This PR needs a bit of context.

Someone on Discord had a WTB order for this item where the SMA was around 122 plat, while people were buying it for ~70 plat. QF placed a WTB order around that lower price. Later on, someone raised the price to 110 plat, which was >= than the current WTS orders.

Instead of rejecting that increase, QF also raised its WTB order to 110 plat. In this case, the user had `max_total_price_cap` set to `-1`.

**Issue**

When *Max Total Price Cap* is disabled, it's still being used as a condition for multiple branches, even ones that aren't related to the knapsack logic. This causes all the price filters to be skipped.

**What this PR does**

This PR removes the `max_total_price_cap` checks from those unrelated branches and adds logging so it's clear why it was skipped.