### PR TITLE
Add HTML entities decoding in chat messages

### DIFF
--- a/src/components/DataDisplay/ChatMessage/ChatMessage.tsx
+++ b/src/components/DataDisplay/ChatMessage/ChatMessage.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from "react";
 import dayjs from "dayjs";
 import calendar from "dayjs/plugin/calendar";
 dayjs.extend(calendar);
+import { decodeHtmlEntities } from "@utils/helper";
 
 export type ChatMessageProps = {
   user: WFMarketTypes.User | undefined;
@@ -42,7 +43,7 @@ export const ChatMessage = ({ user, msg, sender }: ChatMessageProps) => {
                   setOpen((o) => !o);
                 }}
               >
-                {msg.raw_message}
+                {decodeHtmlEntities(msg.raw_message)}
               </Alert>
             </Group>
           </Stack>

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -285,6 +285,16 @@ export const GetItemDisplay = (
   if ("mod_name" in value) fullName += ` ${value.mod_name}`;
   return fullName || "Unknown Item";
 };
+
+export const decodeHtmlEntities = (input: string): string => {
+  try {
+    const doc = new DOMParser().parseFromString(input, "text/html");
+    return doc.documentElement.textContent || "";
+  } catch {
+    return input;
+  }
+};
+
 // At the top of your component or in a separate utils file
 export const getSafePage = (requestedPage: number | undefined, totalPages: number | undefined): number => {
   const page = requestedPage ?? 1;


### PR DESCRIPTION
Decode HTML entities in chat messages so special characters display correctly.

Example:
Before: `It&#39;s not working`
After:  `It's working`