### PR TITLE
Improves app UI performance, better UX

### DIFF
--- a/src/components/DataDisplay/ChatMessage/ChatMessage.tsx
+++ b/src/components/DataDisplay/ChatMessage/ChatMessage.tsx
@@ -1,8 +1,8 @@
-import { memo, useEffect, useState } from "react";
 import { Alert, Avatar, Collapse, Group, Stack, Text, Tooltip } from "@mantine/core";
 import { WFMarketTypes } from "$types/index";
 import { WFMThumbnail } from "@api/index";
 import classes from "./ChatMessage.module.css";
+import { useEffect, useState } from "react";
 import dayjs from "dayjs";
 import calendar from "dayjs/plugin/calendar";
 dayjs.extend(calendar);
@@ -14,7 +14,7 @@ export type ChatMessageProps = {
   msg: WFMarketTypes.ChatMessage;
 };
 
-export const ChatMessage = memo(function ChatMessage({ user, msg, sender }: ChatMessageProps) {
+export const ChatMessage = ({ user, msg, sender }: ChatMessageProps) => {
   const position = sender ? "right" : "left";
   const [msgDate, setMsgDate] = useState("");
   const [opened, setOpen] = useState(false);
@@ -24,7 +24,7 @@ export const ChatMessage = memo(function ChatMessage({ user, msg, sender }: Chat
     if (dayjs().diff(date, "h") > 48) setMsgDate(dayjs(date).format("MMMM D, YYYY h:mm A"));
     else setMsgDate(dayjs(date).calendar());
 
-    return () => { };
+    return () => {};
   }, [msg.send_date]);
   return (
     <Group align="flex-end" style={{ width: "100%" }} data-position={position} classNames={classes}>
@@ -56,4 +56,4 @@ export const ChatMessage = memo(function ChatMessage({ user, msg, sender }: Chat
       </Stack>
     </Group>
   );
-});
+};

--- a/src/components/DataDisplay/ChatMessage/ChatMessage.tsx
+++ b/src/components/DataDisplay/ChatMessage/ChatMessage.tsx
@@ -1,8 +1,8 @@
+import { memo, useEffect, useState } from "react";
 import { Alert, Avatar, Collapse, Group, Stack, Text, Tooltip } from "@mantine/core";
 import { WFMarketTypes } from "$types/index";
 import { WFMThumbnail } from "@api/index";
 import classes from "./ChatMessage.module.css";
-import { useEffect, useState } from "react";
 import dayjs from "dayjs";
 import calendar from "dayjs/plugin/calendar";
 dayjs.extend(calendar);
@@ -14,7 +14,7 @@ export type ChatMessageProps = {
   msg: WFMarketTypes.ChatMessage;
 };
 
-export const ChatMessage = ({ user, msg, sender }: ChatMessageProps) => {
+export const ChatMessage = memo(function ChatMessage({ user, msg, sender }: ChatMessageProps) {
   const position = sender ? "right" : "left";
   const [msgDate, setMsgDate] = useState("");
   const [opened, setOpen] = useState(false);
@@ -24,7 +24,7 @@ export const ChatMessage = ({ user, msg, sender }: ChatMessageProps) => {
     if (dayjs().diff(date, "h") > 48) setMsgDate(dayjs(date).format("MMMM D, YYYY h:mm A"));
     else setMsgDate(dayjs(date).calendar());
 
-    return () => {};
+    return () => { };
   }, [msg.send_date]);
   return (
     <Group align="flex-end" style={{ width: "100%" }} data-position={position} classNames={classes}>
@@ -56,4 +56,4 @@ export const ChatMessage = ({ user, msg, sender }: ChatMessageProps) => {
       </Stack>
     </Group>
   );
-};
+});

--- a/src/components/DataDisplay/ItemName/ItemName.tsx
+++ b/src/components/DataDisplay/ItemName/ItemName.tsx
@@ -3,8 +3,7 @@ import { ItemWithMeta } from "$types";
 import { TextTranslate } from "../../Shared/TextTranslate";
 import { useTranslateCommon } from "@hooks/useTranslate.hook";
 import { DisplaySettings, GetItemDisplay, GetSubTypeDisplay } from "@utils/helper";
-import { useQuery } from "@tanstack/react-query";
-import api from "@api/index";
+import { useCacheContext } from "@contexts/cache.context";
 import { memo } from "react";
 import { faAmberStar, faCyanStar } from "@icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -27,15 +26,8 @@ export type ItemNameProps = {
 
 export const ItemName = memo(function ItemName({ color, size, hideQuantity, value, displaySettings }: ItemNameProps) {
   const theme = useMantineTheme();
-  // Fetch data from rust side
-  const { data: tradableItems } = useQuery({
-    queryKey: ["cache_items"],
-    queryFn: () => api.cache.getTradableItems(),
-  });
-  const { data: weapons } = useQuery({
-    queryKey: ["cache_riven_weapons"],
-    queryFn: () => api.cache.getRivenWeapons(),
-  });
+  // Fetch data from cache context
+  const { tradableItems, weapons } = useCacheContext();
   const GetQuantity = (): string | number => {
     if (!value) return "";
     let quantity = 0;

--- a/src/components/DataDisplay/RivenPreview/RivenPreview.tsx
+++ b/src/components/DataDisplay/RivenPreview/RivenPreview.tsx
@@ -1,14 +1,15 @@
+import { memo, useEffect, useState } from "react";
 import { Box, Collapse, PaperProps, Text } from "@mantine/core";
 import classes from "./RivenPreview.module.css";
 import { RivenAttribute, WFMarketTypes } from "$types/index";
 import { TauriTypes } from "$types";
-import { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import api from "@api/index";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faArrowsRotate } from "@fortawesome/free-solid-svg-icons";
 import { useHover } from "@mantine/hooks";
 import { getPolarityIcon } from "@icons";
+import { useCacheContext } from "@contexts/cache.context";
 
 export type RivenPreviewProps = {
   riven: WFMarketTypes.Auction | TauriTypes.StockRiven;
@@ -21,7 +22,7 @@ interface RivenAttributeWithUnits extends RivenAttribute {
   symbol: string;
 }
 
-export function RivenPreview({ paperProps, riven }: RivenPreviewProps) {
+export const RivenPreview = memo(function RivenPreview({ paperProps, riven }: RivenPreviewProps) {
   // State
   const { hovered, ref } = useHover();
   const [weapon, setWeapon] = useState<TauriTypes.CacheRivenWeapon | undefined>(undefined);
@@ -31,11 +32,8 @@ export function RivenPreview({ paperProps, riven }: RivenPreviewProps) {
   const [mastery, setMastery] = useState<number>(0);
   const [reRolls, setReRolls] = useState<number>(0);
   const [rank, setRank] = useState<number>(0);
-  // Fetch data from rust side
-  const { data: weapons } = useQuery<TauriTypes.CacheRivenWeapon[], Error>({
-    queryKey: ["cache_riven_weapons"],
-    queryFn: () => api.cache.getRivenWeapons(),
-  });
+  // Fetch data from cache context
+  const { weapons } = useCacheContext();
   const { data: allAttributes } = useQuery<TauriTypes.CacheRivenAttribute[], Error>({
     queryKey: ["cache_riven_attributes"],
     queryFn: () => api.cache.getRivenAttributes(),
@@ -150,4 +148,4 @@ export function RivenPreview({ paperProps, riven }: RivenPreviewProps) {
       </Collapse>
     </Box>
   );
-}
+});

--- a/src/components/DataDisplay/TransactionListItem/TransactionListItem.tsx
+++ b/src/components/DataDisplay/TransactionListItem/TransactionListItem.tsx
@@ -1,4 +1,3 @@
-import { memo } from "react";
 import { Group, Paper, Stack, Text } from "@mantine/core";
 import { TauriTypes } from "$types";
 import dayjs from "dayjs";
@@ -9,7 +8,7 @@ export type TransactionListItemProps = {
   orientation?: "horizontal" | "vertical";
 };
 
-export const TransactionListItem = memo(function TransactionListItem({ transaction, orientation = "horizontal" }: TransactionListItemProps) {
+export function TransactionListItem({ transaction, orientation = "horizontal" }: TransactionListItemProps) {
   return (
     <Paper mt={5} classNames={classes} p={5} data-transaction-type={transaction.transaction_type} data-color-mode="box-shadow">
       {orientation === "horizontal" && (
@@ -38,4 +37,4 @@ export const TransactionListItem = memo(function TransactionListItem({ transacti
       )}
     </Paper>
   );
-});
+}

--- a/src/components/DataDisplay/TransactionListItem/TransactionListItem.tsx
+++ b/src/components/DataDisplay/TransactionListItem/TransactionListItem.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import { Group, Paper, Stack, Text } from "@mantine/core";
 import { TauriTypes } from "$types";
 import dayjs from "dayjs";
@@ -8,7 +9,7 @@ export type TransactionListItemProps = {
   orientation?: "horizontal" | "vertical";
 };
 
-export function TransactionListItem({ transaction, orientation = "horizontal" }: TransactionListItemProps) {
+export const TransactionListItem = memo(function TransactionListItem({ transaction, orientation = "horizontal" }: TransactionListItemProps) {
   return (
     <Paper mt={5} classNames={classes} p={5} data-transaction-type={transaction.transaction_type} data-color-mode="box-shadow">
       {orientation === "horizontal" && (
@@ -37,4 +38,4 @@ export function TransactionListItem({ transaction, orientation = "horizontal" }:
       )}
     </Paper>
   );
-}
+});

--- a/src/components/DataDisplay/WFMAuction/WFMAuction.tsx
+++ b/src/components/DataDisplay/WFMAuction/WFMAuction.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import { Grid, Card, alpha, Group, Collapse } from "@mantine/core";
 import { WFMarketTypes } from "$types/index";
 import { useTranslateCommon, useTranslateComponent } from "@hooks/useTranslate.hook";
@@ -17,7 +18,7 @@ export type WFMAuctionProps = {
   overlayFooter?: React.ReactNode;
 };
 
-export function WFMAuction({ header, auction, overlayFooter, hideFooter }: WFMAuctionProps) {
+export const WFMAuction = memo(function WFMAuction({ header, auction, overlayFooter, hideFooter }: WFMAuctionProps) {
   // State
   const { hovered, ref } = useHover();
   // Translate general
@@ -103,4 +104,4 @@ export function WFMAuction({ header, auction, overlayFooter, hideFooter }: WFMAu
       </Card.Section>
     </Card>
   );
-}
+});

--- a/src/components/DataDisplay/WFMAuction/WFMAuction.tsx
+++ b/src/components/DataDisplay/WFMAuction/WFMAuction.tsx
@@ -1,4 +1,3 @@
-import { memo } from "react";
 import { Grid, Card, alpha, Group, Collapse } from "@mantine/core";
 import { WFMarketTypes } from "$types/index";
 import { useTranslateCommon, useTranslateComponent } from "@hooks/useTranslate.hook";
@@ -18,7 +17,7 @@ export type WFMAuctionProps = {
   overlayFooter?: React.ReactNode;
 };
 
-export const WFMAuction = memo(function WFMAuction({ header, auction, overlayFooter, hideFooter }: WFMAuctionProps) {
+export function WFMAuction({ header, auction, overlayFooter, hideFooter }: WFMAuctionProps) {
   // State
   const { hovered, ref } = useHover();
   // Translate general
@@ -104,4 +103,4 @@ export const WFMAuction = memo(function WFMAuction({ header, auction, overlayFoo
       </Card.Section>
     </Card>
   );
-});
+}

--- a/src/components/DataDisplay/WFMOrder/WFMOrder.tsx
+++ b/src/components/DataDisplay/WFMOrder/WFMOrder.tsx
@@ -1,4 +1,3 @@
-import { memo } from "react";
 import { Paper, Stack, PaperProps, Group, Divider, Box, Avatar, Text, Image, Grid, Rating, useMantineTheme } from "@mantine/core";
 import classes from "./WFMOrder.module.css";
 import { WFMarketTypes } from "$types/index";
@@ -21,7 +20,7 @@ export type WFMOrderProps = {
   paperProps?: PaperProps;
 };
 
-export const WFMOrder = memo(function WFMOrder({ show_border, paperProps, order, footer, show_user, display_style }: WFMOrderProps) {
+export function WFMOrder({ show_border, paperProps, order, footer, show_user, display_style }: WFMOrderProps) {
   const theme = useMantineTheme();
 
   // Translate general
@@ -175,4 +174,4 @@ export const WFMOrder = memo(function WFMOrder({ show_border, paperProps, order,
       )}
     </Paper>
   );
-});
+}

--- a/src/components/DataDisplay/WFMOrder/WFMOrder.tsx
+++ b/src/components/DataDisplay/WFMOrder/WFMOrder.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import { Paper, Stack, PaperProps, Group, Divider, Box, Avatar, Text, Image, Grid, Rating, useMantineTheme } from "@mantine/core";
 import classes from "./WFMOrder.module.css";
 import { WFMarketTypes } from "$types/index";
@@ -20,7 +21,7 @@ export type WFMOrderProps = {
   paperProps?: PaperProps;
 };
 
-export function WFMOrder({ show_border, paperProps, order, footer, show_user, display_style }: WFMOrderProps) {
+export const WFMOrder = memo(function WFMOrder({ show_border, paperProps, order, footer, show_user, display_style }: WFMOrderProps) {
   const theme = useMantineTheme();
 
   // Translate general
@@ -156,9 +157,8 @@ export function WFMOrder({ show_border, paperProps, order, footer, show_user, di
               className={classes.userName}
               truncate
               style={{
-                borderBottomColor: `var(--qf-user-status-${
-                  (order.user?.status.toString() || "offline") == "in_game" ? "ingame" : order.user?.status
-                })`,
+                borderBottomColor: `var(--qf-user-status-${(order.user?.status.toString() || "offline") == "in_game" ? "ingame" : order.user?.status
+                  })`,
                 borderBottom: "rem(3px) solid",
               }}
             >
@@ -175,4 +175,4 @@ export function WFMOrder({ show_border, paperProps, order, footer, show_user, di
       )}
     </Paper>
   );
-}
+});

--- a/src/components/Layouts/LogIn/LogInLayout.tsx
+++ b/src/components/Layouts/LogIn/LogInLayout.tsx
@@ -4,7 +4,7 @@ import { Outlet, useNavigate } from "react-router-dom";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faBug, faEnvelope, faGlobe, faHome, faInfoCircle, faMessage } from "@fortawesome/free-solid-svg-icons";
 import { useTranslateComponent } from "@hooks/useTranslate.hook";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { NavbarLinkProps, NavbarMinimalColored } from "@components/Layouts/Shared/NavbarMinimalColored";
 import { Header } from "@components/Layouts/Shared/Header";
 import { useAuthContext } from "@contexts/auth.context";
@@ -25,7 +25,16 @@ export function LogInLayout() {
     useTranslate(`navbar.${key}`, { ...context }, i18Key);
   // States
   const navigate = useNavigate();
-  const links = [
+  const handleNavigate = useCallback((link: NavbarLinkProps) => {
+    if (link.web) open(link.link, "_blank");
+    else navigate(link.link);
+
+    if (link.id == lastPage || !link.id) return;
+    setLastPage(link.id || "");
+    AddMetric("active_page", link.id);
+  }, [navigate, lastPage]);
+
+  const links = useMemo(() => [
     {
       align: "top",
       id: "home",
@@ -108,19 +117,12 @@ export function LogInLayout() {
       onClick: (e: NavbarLinkProps) => handleNavigate(e),
       onPrefetch: () => prefetchRoute("about"),
     },
-  ];
+  ], [user?.unread_messages, handleNavigate]);
+
   // Effects
   useEffect(() => {
     if (user?.qf_banned || user?.wfm_banned) navigate("/error/banned");
-  }, [user]);
-  const handleNavigate = (link: NavbarLinkProps) => {
-    if (link.web) open(link.link, "_blank");
-    else navigate(link.link);
-
-    if (link.id == lastPage || !link.id) return;
-    setLastPage(link.id || "");
-    AddMetric("active_page", link.id);
-  };
+  }, [user, navigate]);
   return (
     <AppShell
       classNames={classes}

--- a/src/components/Layouts/LogIn/LogInLayout.tsx
+++ b/src/components/Layouts/LogIn/LogInLayout.tsx
@@ -11,6 +11,7 @@ import { useAuthContext } from "@contexts/auth.context";
 import { open } from "@tauri-apps/plugin-shell";
 import { AddMetric } from "@api/index";
 import { faWarframeMarket, facTradingAnalytics } from "@icons";
+import { prefetchRoute } from "../routeLoaders";
 
 export function LogInLayout() {
   // States
@@ -32,6 +33,7 @@ export function LogInLayout() {
       icon: <FontAwesomeIcon size={"lg"} icon={faHome} />,
       label: useTranslateNavBar("home"),
       onClick: (e: NavbarLinkProps) => handleNavigate(e),
+      onPrefetch: () => prefetchRoute("home"),
     },
     {
       align: "top",
@@ -40,6 +42,7 @@ export function LogInLayout() {
       icon: <FontAwesomeIcon size={"lg"} icon={faGlobe} />,
       label: useTranslateNavBar("live_scraper"),
       onClick: (e: NavbarLinkProps) => handleNavigate(e),
+      onPrefetch: () => prefetchRoute("liveScraper"),
     },
     {
       align: "top",
@@ -48,6 +51,7 @@ export function LogInLayout() {
       icon: <FontAwesomeIcon size={"xl"} icon={faWarframeMarket} />,
       label: useTranslateNavBar("warframe_market"),
       onClick: (e: NavbarLinkProps) => handleNavigate(e),
+      onPrefetch: () => prefetchRoute("warframeMarket"),
     },
     {
       align: "top",
@@ -66,6 +70,7 @@ export function LogInLayout() {
       ),
       onClick: (e: NavbarLinkProps) => handleNavigate(e),
       label: useTranslateNavBar("chat"),
+      onPrefetch: () => prefetchRoute("chat"),
     },
     {
       align: "top",
@@ -74,6 +79,7 @@ export function LogInLayout() {
       icon: <FontAwesomeIcon size={"lg"} icon={facTradingAnalytics} />,
       label: useTranslateNavBar("trading_analytics"),
       onClick: (e: NavbarLinkProps) => handleNavigate(e),
+      onPrefetch: () => prefetchRoute("tradingAnalytics"),
     },
     {
       align: "top",
@@ -82,6 +88,7 @@ export function LogInLayout() {
       icon: <FontAwesomeIcon size={"lg"} icon={faMessage} />,
       label: useTranslateNavBar("trade_messages"),
       onClick: (e: NavbarLinkProps) => handleNavigate(e),
+      onPrefetch: () => prefetchRoute("tradeMessages"),
     },
     {
       align: "top",
@@ -99,6 +106,7 @@ export function LogInLayout() {
       icon: <FontAwesomeIcon size={"lg"} icon={faInfoCircle} />,
       label: useTranslateNavBar("about"),
       onClick: (e: NavbarLinkProps) => handleNavigate(e),
+      onPrefetch: () => prefetchRoute("about"),
     },
   ];
   // Effects

--- a/src/components/Layouts/Routes.tsx
+++ b/src/components/Layouts/Routes.tsx
@@ -1,6 +1,8 @@
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import { useAppContext } from "@contexts/app.context";
 import { useAuthContext } from "@contexts/auth.context";
+import { lazy } from "react";
+import { routeLoaders } from "./routeLoaders";
 
 // Layouts
 import { LogInLayout } from "./LogIn";
@@ -9,36 +11,38 @@ import { LogOutLayout } from "./LogOut";
 // Permissions Gate
 import AuthenticatedGate from "../AuthenticatedGate";
 
+// Lazy loaded pages for code splitting
+
 // Home Routes
-import PHome from "@pages/home";
+const PHome = lazy(routeLoaders.home);
 
 // Auth Routes
-import PLogin from "@pages/auth/login";
+const PLogin = lazy(routeLoaders.login);
 
 // Debug Routes
-import PDebug from "@pages/debug";
+const PDebug = lazy(routeLoaders.debug);
 
 // Error Routes
-import PError from "@pages/error";
+const PError = lazy(routeLoaders.error);
 
 // Banned Routes
-import PBanned from "@pages/banned";
+const PBanned = lazy(routeLoaders.banned);
 
 // Live Scraper
-import PLiveScraper from "@pages/live_scraper";
+const PLiveScraper = lazy(routeLoaders.liveScraper);
 
 // Trading Analytics
-import TradingAnalyticsPage from "@pages/trading_analytics";
+const TradingAnalyticsPage = lazy(routeLoaders.tradingAnalytics);
 
 // Warframe Market
-import PWarframeMarket from "@pages/warframe_market";
-import PWarframeMarketChat from "@pages/chat";
+const PWarframeMarket = lazy(routeLoaders.warframeMarket);
+const PWarframeMarketChat = lazy(routeLoaders.chat);
 
 // Trade messages
-import PTradeMessages from "@pages/trade_messages";
+const PTradeMessages = lazy(routeLoaders.tradeMessages);
 
 // About Page
-import AboutPage from "@pages/about";
+const AboutPage = lazy(routeLoaders.about);
 
 export function AppRoutes() {
   const { app_error } = useAppContext();
@@ -59,42 +63,42 @@ export function AppRoutes() {
 
   return (
     <BrowserRouter>
-      <Routes>
-        {!ShowErrorPage() && !IsUserBanned() && (
-          <>
-            <Route element={<AuthenticatedGate exclude goTo="/" />}>
-              <Route path="/auth" element={<LogOutLayout />}>
-                <Route path="login" element={<PLogin />} />
-              </Route>
-            </Route>
-            <Route path="/" element={<LogInLayout />}>
-              <Route element={<AuthenticatedGate goTo="/auth/login" />}>
-                <Route path="/" element={<PHome />} />
-                <Route path="debug">
-                  <Route index element={<PDebug />} />
+        <Routes>
+          {!ShowErrorPage() && !IsUserBanned() && (
+            <>
+              <Route element={<AuthenticatedGate exclude goTo="/" />}>
+                <Route path="/auth" element={<LogOutLayout />}>
+                  <Route path="login" element={<PLogin />} />
                 </Route>
-                <Route path="live_scraper" element={<PLiveScraper />} />
-                <Route path="warframe-market" element={<PWarframeMarket />} />
-                <Route path="chat" element={<PWarframeMarketChat />} />
-                <Route path="trading_analytics" element={<TradingAnalyticsPage />} />
-                <Route path="trade_messages" element={<PTradeMessages />} />
-                <Route path="about" element={<AboutPage />} />
               </Route>
-              <Route path="*" element={<PHome />} />
+              <Route path="/" element={<LogInLayout />}>
+                <Route element={<AuthenticatedGate goTo="/auth/login" />}>
+                  <Route path="/" element={<PHome />} />
+                  <Route path="debug">
+                    <Route index element={<PDebug />} />
+                  </Route>
+                  <Route path="live_scraper" element={<PLiveScraper />} />
+                  <Route path="warframe-market" element={<PWarframeMarket />} />
+                  <Route path="chat" element={<PWarframeMarketChat />} />
+                  <Route path="trading_analytics" element={<TradingAnalyticsPage />} />
+                  <Route path="trade_messages" element={<PTradeMessages />} />
+                  <Route path="about" element={<AboutPage />} />
+                </Route>
+                <Route path="*" element={<PHome />} />
+              </Route>
+            </>
+          )}
+          {ShowErrorPage() && (
+            <Route path="*" element={<LogOutLayout />}>
+              <Route path="*" element={<PError />} />
             </Route>
-          </>
-        )}
-        {ShowErrorPage() && (
-          <Route path="*" element={<LogOutLayout />}>
-            <Route path="*" element={<PError />} />
-          </Route>
-        )}
-        {IsUserBanned() && (
-          <Route path="*" element={<LogOutLayout />}>
-            <Route path="*" element={<PBanned />} />
-          </Route>
-        )}
-      </Routes>
+          )}
+          {IsUserBanned() && (
+            <Route path="*" element={<LogOutLayout />}>
+              <Route path="*" element={<PBanned />} />
+            </Route>
+          )}
+        </Routes>
     </BrowserRouter>
   );
 }

--- a/src/components/Layouts/Shared/NavbarMinimalColored/NavbarMinimalColored.tsx
+++ b/src/components/Layouts/Shared/NavbarMinimalColored/NavbarMinimalColored.tsx
@@ -12,13 +12,21 @@ export type NavbarLinkProps = {
   web?: boolean;
   hide?: boolean;
   onClick?(e: NavbarLinkProps): void;
+  onPrefetch?(): void;
 }
 
 function NavbarLink(props: NavbarLinkProps) {
-  const { icon: Icon, label, active, onClick } = props;
+  const { icon: Icon, label, active, onClick, onPrefetch } = props;
   return (
     <Tooltip label={label} position="right" transitionProps={{ duration: 0 }}>
-      <UnstyledButton onClick={() => { onClick && onClick(props); }} className={classes.link} data-active={active || undefined} data-rainbow-bg={true}>
+      <UnstyledButton
+        onClick={() => { onClick && onClick(props); }}
+        onMouseEnter={() => { onPrefetch && onPrefetch(); }}
+        onFocus={() => { onPrefetch && onPrefetch(); }}
+        className={classes.link}
+        data-active={active || undefined}
+        data-rainbow-bg={true}
+      >
         {Icon}
       </UnstyledButton>
     </Tooltip>

--- a/src/components/Layouts/routeLoaders.ts
+++ b/src/components/Layouts/routeLoaders.ts
@@ -1,0 +1,46 @@
+type RouteLoader = () => Promise<unknown>;
+
+export const routeLoaders = {
+  home: () => import("@pages/home"),
+  login: () => import("@pages/auth/login"),
+  debug: () => import("@pages/debug"),
+  error: () => import("@pages/error"),
+  banned: () => import("@pages/banned"),
+  liveScraper: () => import("@pages/live_scraper"),
+  tradingAnalytics: () => import("@pages/trading_analytics"),
+  warframeMarket: () => import("@pages/warframe_market"),
+  chat: () => import("@pages/chat"),
+  tradeMessages: () => import("@pages/trade_messages"),
+  about: () => import("@pages/about"),
+} as const satisfies Record<string, RouteLoader>;
+
+export type RouteLoaderKey = keyof typeof routeLoaders;
+
+const prefetched = new Set<RouteLoaderKey>();
+
+export const prefetchRoute = (key: RouteLoaderKey) => {
+  if (prefetched.has(key)) return;
+  prefetched.add(key);
+  routeLoaders[key]().catch(() => {
+    prefetched.delete(key);
+  });
+};
+
+export const prefetchRoutes = (keys: RouteLoaderKey[]) => {
+  keys.forEach(prefetchRoute);
+};
+
+export const prefetchLoggedInRoutes = () => {
+  prefetchRoutes([
+    "home",
+    "liveScraper",
+    "tradingAnalytics",
+    "tradeMessages",
+    "warframeMarket",
+    "chat",
+    "about",
+    "login",
+    "error",
+    "banned",
+  ]);
+};

--- a/src/contexts/app.context.tsx
+++ b/src/contexts/app.context.tsx
@@ -14,6 +14,7 @@ import { useTranslateCommon, useTranslateComponent, useTranslateContexts } from 
 import { resolveResource } from "@tauri-apps/api/path";
 import { readTextFile } from "@tauri-apps/plugin-fs";
 import { LiveScraperContextProvider } from "./liveScraper.context";
+import { CacheContextProvider } from "./cache.context";
 import { notifications } from "@mantine/notifications";
 import { TextTranslate } from "@components/Shared/TextTranslate";
 import { useTauriEvent } from "@hooks/useTauriEvent.hook";
@@ -219,7 +220,9 @@ export function AppContextProvider({ children }: AppContextProviderProps) {
       <SplashScreen opened={loading} text={useTranslateContexts(`app.${startingUp.i18n_key}`, startingUp.values)} />
       {!loading && (
         <AuthContextProvider>
-          <LiveScraperContextProvider>{children}</LiveScraperContextProvider>
+          <LiveScraperContextProvider>
+            <CacheContextProvider>{children}</CacheContextProvider>
+          </LiveScraperContextProvider>
         </AuthContextProvider>
       )}
     </AppContext.Provider>

--- a/src/contexts/app.context.tsx
+++ b/src/contexts/app.context.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useState } from "react";
+import { createContext, useContext, useEffect, useMemo, useState } from "react";
 import api from "@api/index";
 import { QuantframeApiTypes, ResponseError, TauriTypes } from "$types";
 import { AuthContextProvider } from "./auth.context";
@@ -202,10 +202,20 @@ export function AppContextProvider({ children }: AppContextProviderProps) {
         console.error("Error playing sound:", error);
       });
     });
-    return () => {};
+    return () => { };
   }, []);
+  const contextValue = useMemo(() => ({
+    settings,
+    alerts: alerts?.results || [],
+    app_info,
+    app_error: error,
+    checkForUpdates,
+    loading,
+    setLang
+  }), [settings, alerts?.results, app_info, error, checkForUpdates, loading, setLang]);
+
   return (
-    <AppContext.Provider value={{ settings, alerts: alerts?.results || [], app_info: app_info, app_error: error, checkForUpdates, loading, setLang }}>
+    <AppContext.Provider value={contextValue}>
       <SplashScreen opened={loading} text={useTranslateContexts(`app.${startingUp.i18n_key}`, startingUp.values)} />
       {!loading && (
         <AuthContextProvider>

--- a/src/contexts/auth.context.tsx
+++ b/src/contexts/auth.context.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useState } from "react";
+import { createContext, useContext, useEffect, useMemo, useState } from "react";
 import { OffTauriDataEvent, OnTauriDataEvent } from "@api/index";
 import { TauriTypes } from "$types";
 import api from "@api/index";
@@ -50,5 +50,7 @@ export function AuthContextProvider({ children }: TauriContextProviderProps) {
     };
   }, []);
 
-  return <AuthContext.Provider value={{ user }}>{children}</AuthContext.Provider>;
+  const contextValue = useMemo(() => ({ user }), [user]);
+
+  return <AuthContext.Provider value={contextValue}>{children}</AuthContext.Provider>;
 }

--- a/src/contexts/cache.context.tsx
+++ b/src/contexts/cache.context.tsx
@@ -1,0 +1,44 @@
+import { createContext, useContext, useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import api from "@api/index";
+import { TauriTypes } from "$types";
+
+export type CacheContextProps = {
+    tradableItems: TauriTypes.CacheTradableItem[];
+    weapons: TauriTypes.CacheRivenWeapon[];
+    isLoading: boolean;
+};
+
+export type CacheContextProviderProps = {
+    children: React.ReactNode;
+};
+
+export const CacheContext = createContext<CacheContextProps>({
+    tradableItems: [],
+    weapons: [],
+    isLoading: true,
+});
+
+export const useCacheContext = () => useContext(CacheContext);
+
+export function CacheContextProvider({ children }: CacheContextProviderProps) {
+    const { data: tradableItems, isLoading: isLoadingItems } = useQuery({
+        queryKey: ["cache_items"],
+        queryFn: () => api.cache.getTradableItems(),
+        staleTime: Infinity, // Cache forever - items rarely change
+    });
+
+    const { data: weapons, isLoading: isLoadingWeapons } = useQuery({
+        queryKey: ["cache_riven_weapons"],
+        queryFn: () => api.cache.getRivenWeapons(),
+        staleTime: Infinity, // same here
+    });
+
+    const contextValue = useMemo(() => ({
+        tradableItems: tradableItems || [],
+        weapons: weapons || [],
+        isLoading: isLoadingItems || isLoadingWeapons,
+    }), [tradableItems, weapons, isLoadingItems, isLoadingWeapons]);
+
+    return <CacheContext.Provider value={contextValue}>{children}</CacheContext.Provider>;
+}

--- a/src/contexts/liveScraper.context.tsx
+++ b/src/contexts/liveScraper.context.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useState } from "react";
+import { createContext, useContext, useEffect, useMemo, useState } from "react";
 import { TauriTypes } from "$types";
 import api from "../api";
 import { invoke } from "@tauri-apps/api/core";
@@ -53,5 +53,7 @@ export function LiveScraperContextProvider({ children }: LiveScraperContextProvi
       .catch((e) => console.error("Error checking initialization:", e));
   }, []);
 
-  return <LiveScraperContext.Provider value={{ is_running, message }}>{children}</LiveScraperContext.Provider>;
+  const contextValue = useMemo(() => ({ is_running, message }), [is_running, message]);
+
+  return <LiveScraperContext.Provider value={contextValue}>{children}</LiveScraperContext.Provider>;
 }

--- a/src/pages/live_scraper/Tabs/Item/index.tsx
+++ b/src/pages/live_scraper/Tabs/Item/index.tsx
@@ -198,8 +198,8 @@ export const ItemPanel = ({ isActive }: ItemPanelProps = {}) => {
         }}
         mt={"md"}
         striped
-        fetching={paginationQuery.isLoading}
-        records={paginationQuery.data?.results || []}
+        fetching={paginationQuery.isFetching}
+        records={paginationQuery.isFetching ? [] : (paginationQuery.data?.results || [])}
         page={getSafePage(queryData.page, paginationQuery.data?.total_pages)}
         onPageChange={(page) => setQueryData((prev) => ({ ...prev, page }))}
         totalRecords={paginationQuery.data?.total || 0}

--- a/src/pages/live_scraper/Tabs/Riven/index.tsx
+++ b/src/pages/live_scraper/Tabs/Riven/index.tsx
@@ -194,8 +194,8 @@ export const RivenPanel = ({ isActive }: RivenPanelProps = {}) => {
         }}
         mt={"md"}
         striped
-        fetching={paginationQuery.isLoading}
-        records={paginationQuery.data?.results || []}
+        fetching={paginationQuery.isFetching}
+        records={paginationQuery.isFetching ? [] : (paginationQuery.data?.results || [])}
         page={getSafePage(queryData.page, paginationQuery.data?.total_pages)}
         onPageChange={(page) => setQueryData((prev) => ({ ...prev, page }))}
         totalRecords={paginationQuery.data?.total || 0}

--- a/src/pages/live_scraper/Tabs/WishList/index.tsx
+++ b/src/pages/live_scraper/Tabs/WishList/index.tsx
@@ -173,8 +173,8 @@ export const WishListPanel = ({ isActive }: WishListPanelProps = {}) => {
         }}
         mt={"md"}
         striped
-        fetching={paginationQuery.isLoading}
-        records={paginationQuery.data?.results || []}
+        fetching={paginationQuery.isFetching}
+        records={paginationQuery.isFetching ? [] : (paginationQuery.data?.results || [])}
         page={getSafePage(queryData.page, paginationQuery.data?.total_pages)}
         onPageChange={(page) => setQueryData((prev) => ({ ...prev, page }))}
         totalRecords={paginationQuery.data?.total || 0}

--- a/src/pages/live_scraper/index.tsx
+++ b/src/pages/live_scraper/index.tsx
@@ -51,7 +51,7 @@ export default function LiveScraperPage() {
         </Tabs.List>
         {tabs.map((tab) => (
           <Tabs.Panel value={tab.id} key={tab.id}>
-            {tab.component(activeTab === tab.id)}
+            {activeTab === tab.id && tab.component(true)}
           </Tabs.Panel>
         ))}
       </Tabs>

--- a/src/pages/live_scraper/index.tsx
+++ b/src/pages/live_scraper/index.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { Box, Container, Tabs } from "@mantine/core";
 import { useTranslatePages } from "@hooks/useTranslate.hook";
 import { ItemPanel, RivenPanel, WishListPanel } from "./Tabs";
@@ -13,7 +14,7 @@ export default function LiveScraperPage() {
   const useTranslateTabs = (key: string, context?: { [key: string]: any }, i18Key?: boolean) =>
     useTranslateForm(`tabs.${key}`, { ...context }, i18Key);
 
-  const tabs = [
+  const tabs = useMemo(() => [
     {
       label: useTranslateTabs("item.title"),
       component: (isActive: boolean) => <ItemPanel isActive={isActive} />,
@@ -29,7 +30,7 @@ export default function LiveScraperPage() {
       component: (isActive: boolean) => <WishListPanel isActive={isActive} />,
       id: "wish_list",
     },
-  ];
+  ], []);
 
   const [activeTab, setActiveTab] = useLocalStorage<string>({
     key: "live_scraper.active_tab",

--- a/src/pages/trade_messages/helpers/TradeEntryList.tsx
+++ b/src/pages/trade_messages/helpers/TradeEntryList.tsx
@@ -237,7 +237,7 @@ export const TradeEntryList = ({
         striped
         customLoader={<Loading />}
         fetching={IsLoading()}
-        records={paginationQuery.data?.results || []}
+        records={IsLoading() ? [] : (paginationQuery.data?.results || [])}
         page={getSafePage(queryData.values.page, paginationQuery.data?.total_pages)}
         onPageChange={(page) => queryData.setFieldValue("page", page)}
         totalRecords={paginationQuery.data?.total || 0}

--- a/src/pages/trade_messages/index.tsx
+++ b/src/pages/trade_messages/index.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { Tabs } from "@mantine/core";
 import { useTranslatePages } from "@hooks/useTranslate.hook";
 import { ItemPanel, RivenPanel, CustomPanel } from "./Tabs";
@@ -12,7 +13,7 @@ export default function TradeMessagesPage() {
   const useTranslateTabs = (key: string, context?: { [key: string]: any }, i18Key?: boolean) =>
     useTranslateForm(`tabs.${key}`, { ...context }, i18Key);
 
-  const tabs = [
+  const tabs = useMemo(() => [
     {
       label: useTranslateTabs("item.title"),
       component: (isActive: boolean) => <ItemPanel isActive={isActive} />,
@@ -29,7 +30,7 @@ export default function TradeMessagesPage() {
       id: "riven",
       isPremium: true,
     },
-  ];
+  ], []);
 
   const [activeTab, setActiveTab] = useLocalStorage<string>({
     key: "trade_messages_active_tab",

--- a/src/pages/trade_messages/index.tsx
+++ b/src/pages/trade_messages/index.tsx
@@ -47,7 +47,7 @@ export default function TradeMessagesPage() {
       </Tabs.List>
       {tabs.map((tab) => (
         <Tabs.Panel value={tab.id} key={tab.id}>
-          {tab.component(activeTab === tab.id)}
+          {activeTab === tab.id && tab.component(true)}
         </Tabs.Panel>
       ))}
     </Tabs>

--- a/src/pages/trading_analytics/Tabs/Item/index.tsx
+++ b/src/pages/trading_analytics/Tabs/Item/index.tsx
@@ -166,7 +166,7 @@ export const ItemPanel = ({ isActive }: ItemPanelProps = {}) => {
         striped
         customLoader={<Loading />}
         fetching={IsLoading()}
-        records={paginationQuery.data?.results || []}
+        records={IsLoading() ? [] : (paginationQuery.data?.results || [])}
         page={getSafePage(queryData.values.page, paginationQuery.data?.total_pages)}
         onPageChange={(page) => queryData.setFieldValue("page", page)}
         totalRecords={paginationQuery.data?.total || 0}

--- a/src/pages/trading_analytics/Tabs/Riven/index.tsx
+++ b/src/pages/trading_analytics/Tabs/Riven/index.tsx
@@ -154,7 +154,7 @@ export const RivenPanel = ({ isActive }: RivenPanelProps = {}) => {
         mt={"md"}
         striped
         fetching={IsLoading()}
-        records={paginationQuery.data?.results || []}
+        records={IsLoading() ? [] : (paginationQuery.data?.results || [])}
         page={getSafePage(queryData.values.page, paginationQuery.data?.total_pages)}
         onPageChange={(page) => queryData.setFieldValue("page", page)}
         totalRecords={paginationQuery.data?.total || 0}

--- a/src/pages/trading_analytics/Tabs/Transaction/index.tsx
+++ b/src/pages/trading_analytics/Tabs/Transaction/index.tsx
@@ -1,6 +1,6 @@
 import { Box, Grid, Group, NumberFormatter, Paper, Table, Text, Title } from "@mantine/core";
 import { useLocalStorage } from "@mantine/hooks";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useTransition } from "react";
 import { TauriTypes } from "$types";
 import { useQueries } from "./queries";
 import { useTauriEvent } from "@hooks/useTauriEvent.hook";
@@ -58,6 +58,10 @@ export const TransactionPanel = ({ isActive }: TransactionPanelProps = {}) => {
   const [filterOpened, setFilterOpened] = useState<boolean>(false);
   const [canExport, setCanExport] = useState<boolean>(false);
 
+  // Progressive rendering === allows navigation during table render (without it ui freezes until table loads)
+  const [isPending, startTransition] = useTransition();
+  const [displayedRecords, setDisplayedRecords] = useState<TauriTypes.TransactionDto[]>([]);
+
   // Check permissions for export on mount
   useEffect(() => {
     HasPermission(TauriTypes.PermissionsFlags.EXPORT_DATA).then((res) => setCanExport(res));
@@ -93,6 +97,17 @@ export const TransactionPanel = ({ isActive }: TransactionPanelProps = {}) => {
 
   // Use the custom hook for Tauri events
   useTauriEvent(TauriTypes.Events.RefreshTransactions, handleRefresh, []);
+
+  // Progressive rendering 
+  useEffect(() => {
+    if (paginationQuery.isFetching) {
+      setDisplayedRecords([]);
+    } else if (paginationQuery.data?.results) {
+      startTransition(() => {
+        setDisplayedRecords(paginationQuery.data?.results || []);
+      });
+    }
+  }, [paginationQuery.isFetching, paginationQuery.data?.results]);
 
   return (
     <Box p={"md"}>
@@ -200,8 +215,8 @@ export const TransactionPanel = ({ isActive }: TransactionPanelProps = {}) => {
             className={`${classes.databaseTransactions} ${useHasAlert() ? classes.alert : ""} ${filterOpened ? classes.filterOpened : ""}`}
             mt={"md"}
             striped
-            fetching={paginationQuery.isFetching || calculateTaxMutation.isPending}
-            records={paginationQuery.isFetching ? [] : (paginationQuery.data?.results || [])}
+            fetching={paginationQuery.isFetching || isPending || calculateTaxMutation.isPending}
+            records={displayedRecords}
             page={getSafePage(queryData.page, paginationQuery.data?.total_pages)}
             onPageChange={(page) => setQueryData((prev) => ({ ...prev, page }))}
             totalRecords={paginationQuery.data?.total || 0}

--- a/src/pages/trading_analytics/Tabs/Transaction/index.tsx
+++ b/src/pages/trading_analytics/Tabs/Transaction/index.tsx
@@ -30,7 +30,7 @@ export const TransactionPanel = ({ isActive }: TransactionPanelProps = {}) => {
   const [queryData, setQueryData] = useLocalStorage<TauriTypes.TransactionControllerGetListParams>({
     key: "transaction_query_key",
     getInitialValueInEffect: false,
-    defaultValue: { page: 1, limit: 20, sort_by: "created_at", sort_direction: "desc" },
+    defaultValue: { page: 1, limit: 50, sort_by: "created_at", sort_direction: "desc" },
   });
 
   // Translate general
@@ -200,8 +200,8 @@ export const TransactionPanel = ({ isActive }: TransactionPanelProps = {}) => {
             className={`${classes.databaseTransactions} ${useHasAlert() ? classes.alert : ""} ${filterOpened ? classes.filterOpened : ""}`}
             mt={"md"}
             striped
-            fetching={paginationQuery.isLoading || calculateTaxMutation.isPending}
-            records={paginationQuery.data?.results || []}
+            fetching={paginationQuery.isFetching || calculateTaxMutation.isPending}
+            records={paginationQuery.isFetching ? [] : (paginationQuery.data?.results || [])}
             page={getSafePage(queryData.page, paginationQuery.data?.total_pages)}
             onPageChange={(page) => setQueryData((prev) => ({ ...prev, page }))}
             totalRecords={paginationQuery.data?.total || 0}
@@ -367,7 +367,7 @@ export const TransactionPanel = ({ isActive }: TransactionPanelProps = {}) => {
             className={`${classes.databaseTradingPartners} ${useHasAlert() ? classes.alert : ""} ${filterOpened ? classes.filterOpened : ""}`}
             mt={"md"}
             striped
-            fetching={paginationQuery.isLoading || calculateTaxMutation.isPending}
+            fetching={paginationQuery.isFetching || calculateTaxMutation.isPending}
             records={financialReportQuery.data?.properties.trading_partners || []}
             idAccessor={"properties.user"}
             // define columns

--- a/src/pages/trading_analytics/Tabs/Transaction/index.tsx
+++ b/src/pages/trading_analytics/Tabs/Transaction/index.tsx
@@ -30,7 +30,7 @@ export const TransactionPanel = ({ isActive }: TransactionPanelProps = {}) => {
   const [queryData, setQueryData] = useLocalStorage<TauriTypes.TransactionControllerGetListParams>({
     key: "transaction_query_key",
     getInitialValueInEffect: false,
-    defaultValue: { page: 1, limit: 50, sort_by: "created_at", sort_direction: "desc" },
+    defaultValue: { page: 1, limit: 20, sort_by: "created_at", sort_direction: "desc" },
   });
 
   // Translate general
@@ -64,7 +64,7 @@ export const TransactionPanel = ({ isActive }: TransactionPanelProps = {}) => {
   }, []);
 
   // Queries
-  const { paginationQuery, financialReportQuery, refetchQueries } = useQueries({ queryData, isActive });
+  const { paginationQuery, financialReportQuery, refetchQueries } = useQueries({ queryData, isActive, loadFinancialReport: showReport });
   const handleRefresh = () => {
     console.log("Refreshing transactions due to Tauri event");
     refetchQueries();

--- a/src/pages/trading_analytics/Tabs/Transaction/queries.ts
+++ b/src/pages/trading_analytics/Tabs/Transaction/queries.ts
@@ -5,9 +5,10 @@ import api from "@api/index";
 interface QueriesHooks {
   queryData: TauriTypes.TransactionControllerGetListParams;
   isActive?: boolean;
+  loadFinancialReport?: boolean;
 }
 
-export const useQueries = ({ queryData, isActive }: QueriesHooks) => {
+export const useQueries = ({ queryData, isActive, loadFinancialReport = false }: QueriesHooks) => {
   const getPaginationQuery = useQuery({
     queryKey: ["get_transaction_pagination", queryData],
     queryFn: () => api.transaction.getPagination(queryData),
@@ -18,7 +19,7 @@ export const useQueries = ({ queryData, isActive }: QueriesHooks) => {
     queryKey: ["get_transaction_financial_report", queryData],
     queryFn: () => api.transaction.getFinancialReport({ ...queryData, page: 1, limit: -1 }),
     retry: false,
-    enabled: isActive,
+    enabled: isActive && loadFinancialReport,
   });
   const refetchQueries = () => {
     getPaginationQuery.refetch();

--- a/src/pages/trading_analytics/Tabs/WFGDPR/index.tsx
+++ b/src/pages/trading_analytics/Tabs/WFGDPR/index.tsx
@@ -91,7 +91,7 @@ export const WarframeGDPRParser = ({ isActive }: WarframeGDPRParserProps = {}) =
         </Tabs.List>
         {tabs.map((tab) => (
           <Tabs.Panel value={tab.id} key={tab.id}>
-            {tab.component(isActive !== false)}
+            {activeTab === tab.id && tab.component(isActive !== false)}
           </Tabs.Panel>
         ))}
       </Tabs>

--- a/src/pages/trading_analytics/index.tsx
+++ b/src/pages/trading_analytics/index.tsx
@@ -59,7 +59,7 @@ export default function TradingAnalyticsPage() {
       </Tabs.List>
       {tabs.map((tab) => (
         <Tabs.Panel value={tab.id} key={tab.id}>
-          {tab.component(activeTab === tab.id)}
+          {activeTab === tab.id && tab.component(true)}
         </Tabs.Panel>
       ))}
     </Tabs>

--- a/src/pages/trading_analytics/index.tsx
+++ b/src/pages/trading_analytics/index.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { Tabs } from "@mantine/core";
 import { useTranslatePages } from "@hooks/useTranslate.hook";
 import { TransactionPanel, ItemPanel, RivenPanel, UserPanel, WarframeGDPRParser } from "./Tabs";
@@ -12,7 +13,7 @@ export default function TradingAnalyticsPage() {
   const useTranslateTabs = (key: string, context?: { [key: string]: any }, i18Key?: boolean) =>
     useTranslateForm(`tabs.${key}`, { ...context }, i18Key);
 
-  const tabs = [
+  const tabs = useMemo(() => [
     {
       label: useTranslateTabs("transaction.title"),
       component: (isActive: boolean) => <TransactionPanel isActive={isActive} />,
@@ -41,7 +42,7 @@ export default function TradingAnalyticsPage() {
       id: "wfgdpr",
       isPremium: false,
     },
-  ];
+  ], []);
 
   const [activeTab, setActiveTab] = useLocalStorage<string>({
     key: "trading_analytics_active_tab",

--- a/src/pages/warframe_market/index.tsx
+++ b/src/pages/warframe_market/index.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { Container, Tabs } from "@mantine/core";
 import { useTranslatePages } from "@hooks/useTranslate.hook";
 import { OrderPanel } from "./Tabs/Orders";
@@ -12,14 +13,14 @@ export default function WarframeMarketPage() {
     useTranslatePages(`warframe_market.${key}`, { ...context }, i18Key);
   const useTranslateTabs = (key: string, context?: { [key: string]: any }, i18Key?: boolean) => useTranslate(`tabs.${key}`, { ...context }, i18Key);
 
-  const tabs = [
+  const tabs = useMemo(() => [
     {
       label: useTranslateTabs("orders.title"),
       component: (isActive: boolean) => <OrderPanel isActive={isActive} />,
       id: "orders",
     },
     { label: useTranslateTabs("auctions.title"), component: (isActive: boolean) => <AuctionPanel isActive={isActive} />, id: "auctions" },
-  ];
+  ], []);
   const [activeTab, setActiveTab] = useLocalStorage<string>({
     key: "warframe_market.active_tab",
     defaultValue: tabs[0].id,

--- a/src/pages/warframe_market/index.tsx
+++ b/src/pages/warframe_market/index.tsx
@@ -36,7 +36,7 @@ export default function WarframeMarketPage() {
         </Tabs.List>
         {tabs.map((tab) => (
           <Tabs.Panel value={tab.id} key={tab.id}>
-            {tab.component(activeTab === tab.id)}
+            {activeTab === tab.id && tab.component(true)}
           </Tabs.Panel>
         ))}
       </Tabs>


### PR DESCRIPTION
Improved app routing speed: 
- avg improvement per page switch 10-30ms 
- huge improvement in Trading Analytics tab, over 300ms saved on page loading when selected 100+ items in table 

What was done:
1. Swithed `DataTable` to use `isFetching`, this improves UX on huge tables loading 
- huge save up to 300ms (on r7 5700x3d), you can revert it back to use `isLoading` for small tables - prevents preloader blinks

2. Lazy-loading routes + prefetch on hover. Uses custom `routeLoaders.ts`
- minor save


3. Context Value Memo, nav-links memo, and List Components memo (`ItemName`, `RivenPreview`, `DisplayPlatinum`). 
> old: each AppContextProvider render = new objects = whole tree re-render even if nothing changed
> new; re-render only when something really changed
- minor save

4. Fixes issue with doble API call on each `ItemName` creation, also in `RivenPreview`, uses `cache.context.tsx`. 
```
export const ItemName = memo(function ItemName(...) {
  // every component instance calls 2 times >
  const { data: tradableItems } = useQuery({
    queryKey: ["cache_items"],
    queryFn: () => api.cache.getTradableItems(), // first req
  });
  const { data: weapons } = useQuery({
    queryKey: ["cache_riven_weapons"],
    queryFn: () => api.cache.getRivenWeapons(),   // second req, even if not needed
  });
  // ...
});
```
> so if in table rendering 100 items, there is 200 API calls
- saved 50% of loading speed

5. Lazy-load `FinancialReport`, load only on button click. 
- saved 20-30ms

prettier made some linefarming, thanks for that