### PR TITLE
feat(orders): quick blacklist button in Warframe Market orders

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -364,6 +364,16 @@
           "message": "The order has been successfully deleted."
         }
       },
+      "blacklist_order": {
+        "error": {
+          "title": "Blacklist Error",
+          "message": "An error occurred while trying to blacklist the item."
+        },
+        "success": {
+          "title": "Blacklist Success",
+          "message": "The item has been blacklisted and its listing removed."
+        }
+      },
       "delete_all_orders": {
         "error": {
           "title": "Delete All Orders Error",
@@ -472,6 +482,12 @@
         "message": "This action cannot be undone.",
         "cancel": "Cancel",
         "confirm": "Confirm"
+      },
+      "blacklist_item": {
+        "title": "Blacklist item?",
+        "message": "This will remove your listing from Warframe Market and add the item to your blacklist. This action cannot be undone.",
+        "cancel": "Cancel",
+        "confirm": "Blacklist"
       },
       "delete_multiple_items": {
         "title": "Are you sure?",
@@ -2101,6 +2117,7 @@
             "refresh_tooltip": "Refresh the order list",
             "delete_all_tooltip": "Delete all orders",
             "delete_tooltip": "Delete this order",
+            "blacklist_tooltip": "Blacklist item and remove listing",
             "info_tooltip": "View order details",
             "sell_manual": {
               "buy_tooltip": "Bought manually",

--- a/src/pages/warframe_market/Tabs/Orders/index.tsx
+++ b/src/pages/warframe_market/Tabs/Orders/index.tsx
@@ -6,7 +6,17 @@ import { Loading } from "@components/Shared/Loading";
 import { PaginationFooter } from "@components/Shared/PaginationFooter";
 import { PreviewCard } from "@components/Shared/PreviewCard/PreviewCard";
 import { TextTranslate } from "@components/Shared/TextTranslate";
-import { faArrowDown, faArrowUp, faCartShopping, faInfoCircle, faPen, faRefresh, faSackDollar, faTrashCan } from "@fortawesome/free-solid-svg-icons";
+import {
+  faArrowDown,
+  faArrowUp,
+  faBan,
+  faCartShopping,
+  faInfoCircle,
+  faPen,
+  faRefresh,
+  faSackDollar,
+  faTrashCan,
+} from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useHasAlert } from "@hooks/useHasAlert.hook";
 import { useTauriEvent } from "@hooks/useTauriEvent.hook";

--- a/src/pages/warframe_market/Tabs/Orders/index.tsx
+++ b/src/pages/warframe_market/Tabs/Orders/index.tsx
@@ -51,18 +51,20 @@ export const OrderPanel = ({ isActive }: OrderPanelProps) => {
   const { refetchQueries, paginationQuery, statusCountsQuery } = useStockQueries({ queryData, isActive });
 
   // Mutations
-  const { refreshOrdersMutation, deleteAllOrdersMutation, deleteStockMutation, createStockMutation, sellStockMutation } = useStockMutations({
-    refetchQueries,
-    setLoadingRows,
-  });
+  const { refreshOrdersMutation, deleteAllOrdersMutation, deleteStockMutation, createStockMutation, sellStockMutation, blacklistOrderMutation } =
+    useStockMutations({
+      refetchQueries,
+      setLoadingRows,
+    });
 
   // Modals
-  const { OpenDeleteAllModal, OpenInfoModal, OpenDeleteModal, HandleModalOrder } = useStockModals({
+  const { OpenDeleteAllModal, OpenInfoModal, OpenDeleteModal, OpenBlacklistModal, HandleModalOrder } = useStockModals({
     createStockMutation,
     sellStockMutation,
     useTranslateBasePrompt,
     deleteStockMutation,
     deleteAllOrdersMutation,
+    blacklistOrderMutation,
   });
   const handleRefresh = (_data: any) => {
     refetchQueries(true);
@@ -302,6 +304,18 @@ export const OrderPanel = ({ isActive }: OrderPanelProps) => {
                     onClick={(e) => {
                       e.stopPropagation();
                       OpenInfoModal(order);
+                    }}
+                  />
+                  <ActionWithTooltip
+                    tooltip={useTranslateButtons("blacklist_tooltip")}
+                    icon={faBan}
+                    loading={loadingRows.includes(`${order.id}`)}
+                    color={"orange.7"}
+                    actionProps={{ size: "sm" }}
+                    iconProps={{ size: "xs" }}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      OpenBlacklistModal(order);
                     }}
                   />
                   <ActionWithTooltip

--- a/src/pages/warframe_market/Tabs/Orders/modals.tsx
+++ b/src/pages/warframe_market/Tabs/Orders/modals.tsx
@@ -9,6 +9,9 @@ interface ModalHooks {
   deleteStockMutation: {
     mutateAsync: (id: string) => Promise<any>;
   };
+  blacklistOrderMutation: {
+    mutateAsync: (order: WFMarketTypes.Order) => Promise<any>;
+  };
   deleteAllOrdersMutation: {
     mutateAsync: (order_type?: WFMarketTypes.OrderType) => Promise<any>;
   };
@@ -20,7 +23,7 @@ interface ModalHooks {
   };
 }
 
-export const useStockModals = ({ deleteStockMutation, deleteAllOrdersMutation, createStockMutation, sellStockMutation }: ModalHooks) => {
+export const useStockModals = ({ deleteStockMutation, deleteAllOrdersMutation, createStockMutation, sellStockMutation, blacklistOrderMutation }: ModalHooks) => {
   const OpenSellModal = (order: WFMarketTypes.Order) => {
     modals.openContextModal({
       modal: "prompt",
@@ -111,6 +114,14 @@ export const useStockModals = ({ deleteStockMutation, deleteAllOrdersMutation, c
       onConfirm: async () => await deleteStockMutation.mutateAsync(id),
     });
   };
+  const OpenBlacklistModal = (order: WFMarketTypes.Order) => {
+    modals.openConfirmModal({
+      title: useTranslateCommon("prompts.blacklist_item.title"),
+      children: <Text size="sm">{useTranslateCommon("prompts.blacklist_item.message")}</Text>,
+      labels: { confirm: useTranslateCommon("prompts.blacklist_item.confirm"), cancel: useTranslateCommon("prompts.blacklist_item.cancel") },
+      onConfirm: () => blacklistOrderMutation.mutateAsync(order),
+    });
+  };
   const OpenDeleteAllModal = () => {
     modals.openContextModal({
       modal: "prompt",
@@ -145,6 +156,7 @@ export const useStockModals = ({ deleteStockMutation, deleteAllOrdersMutation, c
   return {
     HandleModalOrder,
     OpenDeleteModal,
+    OpenBlacklistModal,
     OpenDeleteAllModal,
     OpenInfoModal,
   };

--- a/src/pages/warframe_market/Tabs/Orders/modals.tsx
+++ b/src/pages/warframe_market/Tabs/Orders/modals.tsx
@@ -1,8 +1,9 @@
-import { modals } from "@mantine/modals";
-import { Text } from "@mantine/core";
-import { WFMarketTypes } from "$types";
-import { useTranslateCommon, useTranslateEnums } from "@hooks/useTranslate.hook";
+import { TauriTypes, WFMarketTypes } from "$types";
+import { SendTauriEvent } from "@api/index";
 import { ItemDetailsModal, Operations } from "@components/Modals/ItemDetails";
+import { useTranslateCommon, useTranslateEnums } from "@hooks/useTranslate.hook";
+import { Text } from "@mantine/core";
+import { modals } from "@mantine/modals";
 
 interface ModalHooks {
   useTranslateBasePrompt: (key: string, context?: { [key: string]: any }) => string;
@@ -23,7 +24,13 @@ interface ModalHooks {
   };
 }
 
-export const useStockModals = ({ deleteStockMutation, deleteAllOrdersMutation, createStockMutation, sellStockMutation, blacklistOrderMutation }: ModalHooks) => {
+export const useStockModals = ({
+  deleteStockMutation,
+  deleteAllOrdersMutation,
+  createStockMutation,
+  sellStockMutation,
+  blacklistOrderMutation,
+}: ModalHooks) => {
   const OpenSellModal = (order: WFMarketTypes.Order) => {
     modals.openContextModal({
       modal: "prompt",
@@ -119,7 +126,10 @@ export const useStockModals = ({ deleteStockMutation, deleteAllOrdersMutation, c
       title: useTranslateCommon("prompts.blacklist_item.title"),
       children: <Text size="sm">{useTranslateCommon("prompts.blacklist_item.message")}</Text>,
       labels: { confirm: useTranslateCommon("prompts.blacklist_item.confirm"), cancel: useTranslateCommon("prompts.blacklist_item.cancel") },
-      onConfirm: () => blacklistOrderMutation.mutateAsync(order),
+      onConfirm: async () => {
+        await blacklistOrderMutation.mutateAsync(order);
+        SendTauriEvent(TauriTypes.Events.RefreshSettings);
+      },
     });
   };
   const OpenDeleteAllModal = () => {

--- a/src/pages/warframe_market/Tabs/Orders/mutations.ts
+++ b/src/pages/warframe_market/Tabs/Orders/mutations.ts
@@ -1,9 +1,11 @@
-import { WFMarketTypes } from "$types";
+import { TauriTypes, WFMarketTypes } from "$types";
 import api from "@api/index";
+import { useAppContext } from "@contexts/app.context";
 import { createGenericMutation, MutationHooks } from "@utils/genericMutation.helper";
 
 export const useStockMutations = ({ refetchQueries, setLoadingRows }: MutationHooks) => {
   const hooks = { refetchQueries, setLoadingRows };
+  const { settings } = useAppContext();
 
   const refreshOrdersMutation = createGenericMutation(
     {
@@ -73,11 +75,36 @@ export const useStockMutations = ({ refetchQueries, setLoadingRows }: MutationHo
     hooks,
   );
 
+  const blacklistOrderMutation = createGenericMutation(
+    {
+      mutationFn: async (order: WFMarketTypes.Order) => {
+        if (!settings) throw new Error("Settings are not loaded");
+        const wfm_id = order.properties?.wfm_id || order.itemId;
+        const allModes = [TauriTypes.TradeMode.Buy, TauriTypes.TradeMode.Sell, TauriTypes.TradeMode.Wishlist];
+        const blacklist = settings.live_scraper.stock_item.blacklist || [];
+        const updatedBlacklist = [...blacklist.filter((b) => b.wfm_id !== wfm_id), { wfm_id, disabled_for: allModes }];
+        await api.app.updateSettings({
+          ...settings,
+          live_scraper: {
+            ...settings.live_scraper,
+            stock_item: { ...settings.live_scraper.stock_item, blacklist: updatedBlacklist },
+          },
+        });
+        return api.order.deleteById(order.id);
+      },
+      successKey: "blacklist_order",
+      errorKey: "blacklist_order",
+      getLoadingId: (order: WFMarketTypes.Order) => `${order.id}`,
+    },
+    hooks,
+  );
+
   return {
     refreshOrdersMutation,
     deleteAllOrdersMutation,
     createStockMutation,
     sellStockMutation,
     deleteStockMutation,
+    blacklistOrderMutation,
   };
 };

--- a/src/pages/warframe_market/Tabs/Orders/mutations.ts
+++ b/src/pages/warframe_market/Tabs/Orders/mutations.ts
@@ -82,7 +82,7 @@ export const useStockMutations = ({ refetchQueries, setLoadingRows }: MutationHo
         const wfm_id = order.properties?.wfm_id || order.itemId;
         const allModes = [TauriTypes.TradeMode.Buy, TauriTypes.TradeMode.Sell, TauriTypes.TradeMode.Wishlist];
         const blacklist = settings.live_scraper.stock_item.blacklist || [];
-        const updatedBlacklist = [...blacklist.filter((b) => b.wfm_id !== wfm_id), { wfm_id, disabled_for: allModes }];
+        const updatedBlacklist = [...blacklist.filter((b) => b.wfmId !== wfm_id), { wfmId: wfm_id, disabled_for: allModes }];
         await api.app.updateSettings({
           ...settings,
           live_scraper: {


### PR DESCRIPTION
Closes #111 — quick blacklist button on Warframe Market orders.

## What was added
A per-order button on each card in the **Warframe Market → Orders** tab (orange ban icon, left of the delete button). It opens a confirm dialog, then in one action blacklists the item and removes its listing from Warframe Market.

## Behavior
On confirm, `blacklistOrderMutation` (`src/pages/warframe_market/Tabs/Orders/mutations.ts`):
1. Resolves the item's `wfm_id` from `order.properties?.wfm_id ?? order.itemId`.
2. Merges it into `settings.live_scraper.stock_item.blacklist` with `disabled_for: [Buy, Sell, Wishlist]`, de-duped by `wfm_id`, and persists via `app_update_settings`.
3. Removes the WFM listing via `order_delete_by_id`.
