### PR TITLE
Added "gzip" and "deflate" as dependencies for reqwest

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -260,6 +260,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3976abdc8fe7d1133d43d304afd42abdf5bc3e1319d263d223bde07b5efc4be8"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-executor"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -921,6 +933,23 @@ dependencies = [
  "bytes",
  "memchr",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "concurrent-queue"
@@ -7102,13 +7131,18 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "async-compression",
  "bitflags 2.11.1",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "iri-string",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -39,7 +39,7 @@ tauri-plugin-clipboard-manager = "2.3.0"
 # Other dependencies
 aes = "0.8.4"
 cbc = { version = "0.1.2", features = ["std"] }
-reqwest = { version = "0.12.19", features = ["json"] }
+reqwest = { version = "0.12.19", features = ["json", "gzip", "deflate"] }
 tokio = {version =  "1.45.1", features = ["full"] }
 regex = "1.9.1"
 chrono = "0.4"

--- a/src-tauri/qf_api/Cargo.toml
+++ b/src-tauri/qf_api/Cargo.toml
@@ -16,7 +16,7 @@ tokio = {version =  "1.45.1", features = ["full", "rt-multi-thread"] }
 serde = {version =  "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 serde_urlencoded = "0.7.1"
-reqwest = { version = "0.12.19", features = ["json"] }
+reqwest = { version = "0.12.19", features = ["json", "gzip", "deflate"] }
 rand = "0.9.1"
 tokio-tungstenite = { version = "0.26.2", features = ["native-tls"] }
 futures-util = "0.3.31"


### PR DESCRIPTION
My internet connection is very bad and running the live scraper hogs almost all of my bandwidth.
I added gzip and deflate as dependencies which drastically reduced bandwidth usage for me and made Quantframe usable when i actually needed some of my bandwidth or wanted to play warframe with less than 1000 ping.

Maybe others who can barely load a jpeg aswell will benifit from this too...