### PR TITLE
perf: reuse reqwest clients

### DIFF
--- a/src-tauri/qf_api/src/client.rs
+++ b/src-tauri/qf_api/src/client.rs
@@ -57,6 +57,7 @@ pub type ClientCallback = Box<dyn Fn(&str, &Value) + Send + Sync>;
 #[derive(Clone)]
 pub struct Client {
     self_arc: OnceLock<Arc<Client>>,
+    http_client: reqwest::Client,
     pub token: String,
     app_id: String,
     platform: String,
@@ -87,6 +88,7 @@ impl Client {
             .get_or_init(|| {
                 Arc::new(Self {
                     self_arc: OnceLock::new(),
+                    http_client: self.http_client.clone(),
                     token: self.token.clone(),
                     app_id: self.app_id.clone(),
                     platform: self.platform.clone(),
@@ -148,6 +150,7 @@ impl Client {
     ) -> Self {
         Self {
             self_arc: OnceLock::new(),
+            http_client: reqwest::Client::new(),
             token: token.to_string(),
             app_id: app_id.to_string(),
             platform: platform.to_string(),
@@ -255,13 +258,10 @@ impl Client {
                 .collect(),
         );
 
-        // Create the HTTP client with the headers
-        let http_client = reqwest::Client::builder()
-            .default_headers(default_headers)
-            .build()
-            .unwrap();
-
-        let mut builder = http_client.request(method, &url);
+        let mut builder = self
+            .http_client
+            .request(method, &url)
+            .headers(default_headers);
         // If the client needs a body, serialize it
         if let Some(b) = body {
             builder = builder.json(&b);

--- a/src-tauri/src/app/types/settings/discord_notify.rs
+++ b/src-tauri/src/app/types/settings/discord_notify.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use utils::{get_location, info, Error, LoggerOptions};
 
-use crate::APP;
+use crate::{APP, HTTP_CLIENT};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct DiscordNotify {
@@ -50,7 +50,7 @@ impl DiscordNotify {
         let tauri_app = APP.get().expect("App handle not found");
         let app_info = tauri_app.package_info().clone();
         tauri::async_runtime::spawn(async move {
-            let client = reqwest::Client::new();
+            let client = HTTP_CLIENT.get_or_init(reqwest::Client::new);
             let timestamp = chrono::Local::now()
                 .to_utc()
                 .format("%Y-%m-%dT%H:%M:%S%.3fZ")

--- a/src-tauri/src/app/types/settings/webhook_notify.rs
+++ b/src-tauri/src/app/types/settings/webhook_notify.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use utils::{get_location, info, Error, LoggerOptions};
 
-use crate::APP;
+use crate::{APP, HTTP_CLIENT};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct WebHookNotify {
@@ -24,7 +24,7 @@ impl WebHookNotify {
         let tauri_app = APP.get().expect("App handle not found");
         let app_info = tauri_app.package_info().clone();
         tauri::async_runtime::spawn(async move {
-            let client = reqwest::Client::new();
+            let client = HTTP_CLIENT.get_or_init(reqwest::Client::new);
             let res = client
                 .post(&url)
                 .header("Content-Type", "application/json")

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -42,6 +42,7 @@ mod log_parser;
 mod types;
 
 pub static APP: OnceLock<tauri::AppHandle> = OnceLock::new();
+pub(crate) static HTTP_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
 pub static DATABASE: OnceLock<DatabaseConnection> = OnceLock::new();
 pub static HAS_STARTED: OnceLock<bool> = OnceLock::new();
 pub static APP_ERROR: OnceLock<Mutex<Option<Error>>> = OnceLock::new();


### PR DESCRIPTION
Fixes #126 
## changes
- qf_api::Client now creates a reqwest::Client once during initialization and reuses it for all QF API requests.
- Dynamic headers, auth tokens, additional request headers, rate limiting, and error handling remain unchanged for each request.
- Discord and webhook notifications use a shared, lazily initialized `reqwest::Client`.

As a result, TCP/TLS connections remain in the pool and are reused instead of being reestablished for each request. Additional manual testing of QF requests, Discord, and webhooks is appreciated. I visited all the pages once and performed actions that triggered multiple requests. Nothing crashed on me, everything worked as intended.